### PR TITLE
Potential fix for code scanning alert no. 6: DOM text reinterpreted as HTML

### DIFF
--- a/.github/workflows/bug-issue-creator.yml
+++ b/.github/workflows/bug-issue-creator.yml
@@ -1,5 +1,9 @@
 name: Bug Issue Creator
 
+permissions:
+  contents: read
+  issues: write
+
 on:
   pull_request:
     types:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,5 +1,7 @@
 # Remove this file if CodeQL is not needed.
 name: CodeQL Analysis
+permissions:
+  contents: read
 
 on:
   push:

--- a/compat.js
+++ b/compat.js
@@ -63,7 +63,7 @@ if (!window.console) {
             stringify: function(obj) {
                 // Very basic stringify implementation
                 if (obj === null || obj === undefined) return 'null';
-                if (typeof obj === 'string') return '"' + obj.replace(/"/g, '\\"') + '"';
+                if (typeof obj === 'string') return '"' + obj.replace(/["\\]/g, '\\$&') + '"';
                 if (typeof obj === 'number' || typeof obj === 'boolean') return String(obj);
                 if (Array.isArray(obj)) {
                     return '[' + obj.map(function(item) {

--- a/recipes/js/compat.js
+++ b/recipes/js/compat.js
@@ -3,6 +3,17 @@
  * Supports: IE8+, Firefox 16+, early Chrome versions
  */
 
+// Utility function to sanitize URLs
+function sanitizeUrl(url) {
+    try {
+        var parsedUrl = new URL(url, window.location.origin);
+        return parsedUrl.pathname + parsedUrl.search + parsedUrl.hash;
+    } catch (e) {
+        console.error('Invalid URL:', url);
+        return '';
+    }
+}
+
 // Polyfill for console (IE8 crashes when console is undefined and DevTools not open)
 if (!window.console) {
     window.console = {
@@ -445,8 +456,9 @@ function fixRSSForIE() {
                 if (window.navigator.userAgent.indexOf('Trident/') > -1) {
                     // Only intercept in IE
                     e.preventDefault();
+                    var sanitizedUrl = sanitizeUrl(this.getAttribute('data-rss-url'));
                     window.location = 'read:' + window.location.protocol + '//' + 
-                                    window.location.host + '/' + this.getAttribute('data-rss-url');
+                                    window.location.host + '/' + sanitizedUrl;
                 }
             });
         }

--- a/recipes/js/compat.js
+++ b/recipes/js/compat.js
@@ -7,7 +7,9 @@
 function sanitizeUrl(url) {
     try {
         var parsedUrl = new URL(url, window.location.origin);
-        return parsedUrl.pathname + parsedUrl.search + parsedUrl.hash;
+        return encodeURIComponent(parsedUrl.pathname) + 
+               encodeURIComponent(parsedUrl.search) + 
+               encodeURIComponent(parsedUrl.hash);
     } catch (e) {
         console.error('Invalid URL:', url);
         return '';
@@ -456,9 +458,14 @@ function fixRSSForIE() {
                 if (window.navigator.userAgent.indexOf('Trident/') > -1) {
                     // Only intercept in IE
                     e.preventDefault();
-                    var sanitizedUrl = sanitizeUrl(this.getAttribute('data-rss-url'));
-                    window.location = 'read:' + window.location.protocol + '//' + 
-                                    window.location.host + '/' + sanitizedUrl;
+                    var rssUrl = this.getAttribute('data-rss-url');
+                    if (rssUrl && rssUrl.startsWith('http')) { // Basic validation
+                        var sanitizedUrl = sanitizeUrl(rssUrl);
+                        window.location = 'read:' + window.location.protocol + '//' + 
+                                        window.location.host + '/' + sanitizedUrl;
+                    } else {
+                        console.error('Invalid RSS URL:', rssUrl);
+                    }
                 }
             });
         }


### PR DESCRIPTION
Potential fix for [https://github.com/julerobb1/-belllabs/security/code-scanning/6](https://github.com/julerobb1/-belllabs/security/code-scanning/6)

To fix the issue, the `data-rss-url` attribute value should be sanitized or validated before being used in constructing the URL. This ensures that any malicious input is neutralized, preventing exploitation. The best approach is to use a whitelist-based validation to ensure the value conforms to expected patterns (e.g., a valid URL format). Alternatively, escaping meta-characters in the value can mitigate the risk.

Changes to make:
1. Add a utility function to validate or sanitize the `data-rss-url` value.
2. Replace the direct usage of `this.getAttribute('data-rss-url')` with the sanitized/validated value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
