### PR TITLE
Potential fix for code scanning alert no. 5: DOM text reinterpreted as HTML

### DIFF
--- a/compat.js
+++ b/compat.js
@@ -443,8 +443,9 @@ function fixRSSForIE() {
                 if (window.navigator.userAgent.indexOf('Trident/') > -1) {
                     // Only intercept in IE
                     e.preventDefault();
+                    var sanitizedUrl = encodeURIComponent(this.getAttribute('data-rss-url'));
                     window.location = 'read:' + window.location.protocol + '//' + 
-                                    window.location.host + '/' + this.getAttribute('data-rss-url');
+                                    window.location.host + '/' + sanitizedUrl;
                 }
             });
         }


### PR DESCRIPTION
Potential fix for [https://github.com/julerobb1/-belllabs/security/code-scanning/5](https://github.com/julerobb1/-belllabs/security/code-scanning/5)

To fix the issue, we need to ensure that the value retrieved from `this.getAttribute('data-rss-url')` is sanitized or validated before being used. A safe approach is to encode the value to prevent any malicious input from being interpreted as executable code. We can use `encodeURIComponent` to encode the value, ensuring that it is treated as a literal string in the URL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
